### PR TITLE
Set the correct web driver option for script errors

### DIFF
--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/BaseConfiguration.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/BaseConfiguration.scala
@@ -30,7 +30,7 @@ class BaseConfiguration() {
     configurations += "enableJavaScript" ->
       ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setJavaScriptEnabled(true))
     configurations += "throwOnJSError" ->
-      ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnFailingStatusCode(throwOnError))
+      ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnScriptError(throwOnError))
   }
 
   /**
@@ -38,20 +38,20 @@ class BaseConfiguration() {
     */
   def disableJavaScript(): Unit = {
     configurations += "enableJavaScript" -> ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setJavaScriptEnabled(false))
-    configurations += "throwOnJSError" -> ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnFailingStatusCode(false))
+    configurations += "throwOnJSError" -> ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnScriptError(false))
   }
 
   /**
     * Throw on JavaScript Error. Preferably use [[BaseConfiguration.disableJavaScript()]], as the two configurations only make sense when combined.
     */
   def throwOnJavaScriptError(): Unit = configurations += "throwOnJSError" ->
-    ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnFailingStatusCode(true))
+    ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnScriptError(true))
 
   /**
     * Silently swallow JavaScript errors. Preferably use [[BaseConfiguration.disableJavaScript()]], as the two configurations only make sense when combined.
     */
   def swallowJavaScriptErrors(): Unit = configurations += "throwOnJSError" ->
-    ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnFailingStatusCode(false))
+    ((webDriver: WebClientExposingDriver) => webDriver.getOptions.setThrowExceptionOnScriptError(false))
 
   /**
     * Enable CSS evaluation in the webDriver.


### PR DESCRIPTION
Currently, the options for toggling exceptions on script errors toggle a different web driver option (exception on failing status code).