### PR TITLE
ScalaWebTest-33 Provide gauge functions via trait - changed the core.…

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -207,16 +207,23 @@ class HomepageSpec extends IntegrationFlatSpec {
                     example in ScalaWebTest's own integration tests.
 
 {% highlight scala %}
+import org.scalatest.AppendedClues
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.SpanSugar._
+import org.scalawebtest.core.gauge.HtmlGauge
 import org.scalawebtest.core.{FormBasedLogin, IntegrationFlatSpec}
 
-trait ScalaWebTestBaseSpec extends IntegrationFlatSpec with FormBasedLogin {
-override val host = "http://localhost:8080"
-override val loginPath = "/fakeLogin.jsp"
+import scala.language.postfixOps
 
-override val projectRoot = ""
+trait ScalaWebTestBaseSpec extends IntegrationFlatSpec with AemTweaks with FormBasedLogin with HtmlGauge {
+    override val host = "http://localhost:8080"
+    override val loginPath = "/fakeLogin.jsp"
 
-override def loginTimeout = Timeout(5 seconds)
-} {% endhighlight %}
+    override val projectRoot = ""
+
+    override def loginTimeout = Timeout(5 seconds)
+}
+{% endhighlight %}
 
                     This BaseTrait uses FlatSpec style, adds the tweaks from the AEM module, and uses FormBasedLogin.
 
@@ -265,7 +272,8 @@ class HomepageSpec extends IntegrationFlatSpec {
                         Let's have a look at a simple example to get an idea how those gauges work.</p>
 
 {% highlight scala %}
-import org.scalawebtest.core.gauge.Gauge.fit
+package org.scalawebtest.integration.gauge
+
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class SimpleGaugeSpec extends ScalaWebTestBaseSpec {
@@ -473,9 +481,9 @@ ScalaTestFailure
 {% highlight scala %}
 import org.scalatest.exceptions.TestFailedException
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.core.gauge.ElementGaugeBuilder.GaugeFromElement
+import org.scalawebtest.core.gauge.HtmlElementGauge
 
-class ElementGaugeSpec extends ScalaWebTestBaseSpec {
+class ElementGaugeSpec extends ScalaWebTestBaseSpec with HtmlElementGauge {
   path = "/galleryOverview.jsp"
 
   def images = findAll(CssSelectorQuery("ul div.image_columns"))
@@ -552,7 +560,8 @@ fit(<a href="@regex http:\\/\\/[a-zA-Z]+\.scalawebtest.org.*,"></a>)
                         better in your current context.</p>
 
 {% highlight scala %}
-import org.scalawebtest.core.gauge.Gauge.NotFit
+package org.scalawebtest.integration.gauge
+
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class LoggedInSpec extends ScalaWebTestBaseSpec{
@@ -602,10 +611,11 @@ found
                     <p>Lets try this out using a page with protected content. On first load a form will be shown, after logging in the form
                         disappears, instead the text <i>sensitive information</i> appears.</p>
 {% highlight scala%}
-import org.scalawebtest.core.gauge.Gauge.{NotFit, fits}
+package org.scalawebtest.integration.gauge
+
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
-class LoginSpec extends ScalaWebTestBaseSpec{
+class LoginSpec extends ScalaWebTestBaseSpec {
     path = "/protectedContent.jsp"
 
     "When accessing protectedContent it" should "show the login form" in {
@@ -789,9 +799,9 @@ class ReducedJsonSpec extends ScalaWebTestBaseSpec {
                     </p>
 {% highlight scala %}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeFromResponse.fitsValues
+import org.scalawebtest.json.JsonGauge
 
-class DocumentFitsValuesSpec extends ScalaWebTestBaseSpec {
+class DocumentFitsValuesSpec extends ScalaWebTestBaseSpec extends JsonGauge {
   path = "/jsonResponse.json.jsp"
 
   "FitsValues" should "report success, when the json gauge contains the same values as the response it is tested against" in {
@@ -814,10 +824,10 @@ class DocumentFitsValuesSpec extends ScalaWebTestBaseSpec {
 {% highlight scala %}
 import org.scalatest.exceptions.TestFailedException
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
+import org.scalawebtest.json.JsonGauge
 import play.api.libs.json.{JsValue, Json}
 
-class DijkstraJsonGaugeSpec extends ScalaWebTestBaseSpec {
+class DijkstraJsonGaugeSpec extends ScalaWebTestBaseSpec extends JsonGauge {
   path = "/dijkstra.json"
   def dijkstra = Json.parse(webDriver.getPageSource)
 
@@ -860,10 +870,10 @@ class DijkstraJsonGaugeSpec extends ScalaWebTestBaseSpec {
 {% highlight scala %}
 import org.scalatest.exceptions.TestFailedException
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
+import org.scalawebtest.json.JsonGauge
 import play.api.libs.json.{JsValue, Json}
 
-class DijkstraJsonGaugeFitsTypesSpec extends ScalaWebTestBaseSpec {
+class DijkstraJsonGaugeFitsTypesSpec extends ScalaWebTestBaseSpec extends JsonGauge {
   path = "/dijkstra.json"
   def dijkstra = Json.parse(webDriver.getPageSource)
 
@@ -938,10 +948,10 @@ class DijkstraJsonGaugeFitsTypesSpec extends ScalaWebTestBaseSpec {
                     For this situation <i>containsElementFitting values/types/typesAndArraySizes of</i> exists.</p>
 {% highlight scala %}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
+import org.scalawebtest.json.JsonGauge
 import play.api.libs.json.{JsLookupResult, JsValue, Json}
 
-class ContainsElementFittingSpec extends ScalaWebTestBaseSpec {
+class ContainsElementFittingSpec extends ScalaWebTestBaseSpec extends JsonGauge {
   path = "/jsonResponse.json.jsp"
   def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
   def universities: JsLookupResult = { dijkstra \ "universities" }

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
@@ -27,7 +27,7 @@ import scala.xml._
 /**
   * Gauge provides functions to write integration tests with very low effort. For a detailed description of it's usage,
   * see [[org.scalawebtest.core.gauge.Gauge.fits]] and [[org.scalawebtest.core.gauge.Gauge.doesnt.fit]]
-  * as well as [[org.scalawebtest.core.gauge.ElementGaugeBuilder.GaugeFromElement.fits]] and [[org.scalawebtest.core.gauge.ElementGaugeBuilder.GaugeFromElement.fits]]
+  * as well as [[org.scalawebtest.core.gauge.HtmlElementGauge$.GaugeFromElement.fits]] and [[org.scalawebtest.core.gauge.HtmlElementGauge$.GaugeFromElement.fits]]
   */
 class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) extends Assertions {
   val MISFIT_RELEVANCE_START_VALUE: Int = 0
@@ -331,7 +331,11 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
 
 }
 
-object Gauge {
+@deprecated("Please switch to the HtmlGauge object or extend the HtmlGauge trait. The Gauge object will be removed in a future version, for clear disambiguation between HtmlGauge and JsonGauge", "ScalaWebTest 1.1.0")
+object Gauge extends HtmlGauge
+object HtmlGauge extends HtmlGauge
+
+trait HtmlGauge {
   /**
     * Assert that the current document `fits` the HTML snippet provided as definition for the `Gauge`.
     *

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
@@ -22,10 +22,16 @@ import org.scalawebtest.core.WebClientExposingDriver
 import scala.language.reflectiveCalls
 import scala.xml.NodeSeq
 
+
 /**
   * Helper object to provide functions to fluently build a [[org.scalawebtest.core.gauge.Gauge]], to verify an [[org.scalatest.selenium.WebBrowser.Element]] instead of a complete document.
   */
-object ElementGaugeBuilder {
+object HtmlElementGauge extends HtmlElementGauge
+
+/**
+  * Helper trait to provide functions to fluently build a [[org.scalawebtest.core.gauge.Gauge]], to verify an [[org.scalatest.selenium.WebBrowser.Element]] instead of a complete document.
+  */
+trait HtmlElementGauge {
   type Element = {def underlying: WebElement}
 
   implicit class GaugeFromElement(element: Element) {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/ScalaWebTestBaseSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/ScalaWebTestBaseSpec.scala
@@ -17,11 +17,12 @@ package org.scalawebtest.integration
 import org.scalatest.AppendedClues
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.SpanSugar._
+import org.scalawebtest.core.gauge.HtmlGauge
 import org.scalawebtest.core.{FormBasedLogin, IntegrationFlatSpec}
 
 import scala.language.postfixOps
 
-trait ScalaWebTestBaseSpec extends IntegrationFlatSpec with FormBasedLogin with AppendedClues {
+trait ScalaWebTestBaseSpec extends IntegrationFlatSpec with FormBasedLogin with AppendedClues with HtmlGauge{
   override val host = "http://localhost:9090"
   override val loginPath = "/fakeLogin.jsp"
 

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extending/ExtendingMatchers.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extending/ExtendingMatchers.scala
@@ -1,6 +1,6 @@
 package org.scalawebtest.integration.extending
 
-import org.scalawebtest.core.gauge.Gauge.{doesnt, fits}
+import org.scalawebtest.core.gauge.HtmlGauge.{doesnt, fits}
 import org.scalawebtest.core.gauge._
 import org.scalawebtest.core.gauge.Matchers.{AttributeMatcher, TextMatcher}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extensions/aem/WcmmodeChangingSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extensions/aem/WcmmodeChangingSpec.scala
@@ -2,7 +2,7 @@ package org.scalawebtest.integration.extensions.aem
 
 import org.scalatest.time.SpanSugar._
 import org.scalawebtest.aem.WcmMode
-import org.scalawebtest.core.gauge.Gauge.fit
+import org.scalawebtest.core.gauge.HtmlGauge.fit
 
 import scala.language.postfixOps
 

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extensions/aem/WcmmodeDefaultSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/extensions/aem/WcmmodeDefaultSpec.scala
@@ -1,7 +1,7 @@
 package org.scalawebtest.integration.extensions.aem
 
 import org.scalatest.time.SpanSugar._
-import org.scalawebtest.core.gauge.Gauge.fit
+import org.scalawebtest.core.gauge.HtmlGauge.fit
 
 import scala.language.postfixOps
 

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ContainsSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ContainsSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.fits
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class ContainsSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementGaugeObjectSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementGaugeObjectSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalawebtest.integration.gauge
+
+import org.scalawebtest.core.gauge.HtmlElementGauge.GaugeFromElement
+import org.scalawebtest.integration.ScalaWebTestBaseSpec
+
+class ElementGaugeObjectSpec extends ScalaWebTestBaseSpec {
+  path = "/galleryOverview.jsp"
+
+  def images = findAll(CssSelectorQuery("ul div.image_columns"))
+
+  val imageGauge = <div class="columns image_columns">
+    <a href="@regex \/gallery\/image\/\d">
+      <figure class="obj_aspect_ratio">
+        <noscript>
+          <img class="obj_full" src="@regex \/image\/\d\.jpg\?w=600"></img>
+        </noscript>
+        <img class="obj_full lazyload" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-sizes="auto"></img>
+      </figure>
+    </a>
+  </div>
+
+  "The element gauge" should "successfully verify if single elements fit the given gauge" in {
+    images.size should be > 5 withClue " - gallery didn't contain the expected amount of images"
+
+    for (image <- images) {
+      image fits imageGauge
+    }
+  }
+}

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementOrderSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementOrderSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.{doesnt, fits}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class ElementOrderSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementsListSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementsListSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.fits
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class ElementsListSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlElementGaugeSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlElementGaugeSpec.scala
@@ -15,10 +15,10 @@
 package org.scalawebtest.integration.gauge
 
 import org.scalatest.exceptions.TestFailedException
+import org.scalawebtest.core.gauge.HtmlElementGauge
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.core.gauge.ElementGaugeBuilder.GaugeFromElement
 
-class ElementGaugeSpec extends ScalaWebTestBaseSpec {
+class HtmlElementGaugeSpec extends ScalaWebTestBaseSpec with HtmlElementGauge {
   path = "/galleryOverview.jsp"
 
   def images = findAll(CssSelectorQuery("ul div.image_columns"))

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlGaugeObjectSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlGaugeObjectSpec.scala
@@ -14,30 +14,24 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
+import org.scalawebtest.core.IntegrationFlatSpec
+import org.scalawebtest.core.gauge.HtmlGauge._
 
-class ExactSpec extends ScalaWebTestBaseSpec {
-  path = "/navigation.jsp"
-  "The default matcher" should "exactly match attributes" in {
-    fits(
-      <nav>
-        <ul>
-          <li>
-            <a href="/path/to/first/element">first navigation element</a>
-          </li>
-        </ul>
-      </nav>
-    )
+class HtmlGaugeObjectSpec extends IntegrationFlatSpec {
+  override val host = "http://localhost:9090"
+
+  path = "/index.jsp"
+
+  "CheckingGauge" should "work with fits" in {
+    fits(<h1>Unic AEM Testing - Mock Server</h1>)
   }
-  it should "exactly match text" in {
-    fits(
-      <nav>
-        <ul>
-          <li>
-            <a href="/path/to/first/element">first navigation element</a>
-          </li>
-        </ul>
-      </nav>
-    )
+  it should "work with fit (synonym of fits)" in {
+    fit(<h1>Unic AEM Testing - Mock Server</h1>)
+  }
+  it should "work with doesnt fit" in {
+    doesnt fit <h2>Unic AEM Testing - False Text and Tag</h2>
+  }
+  it should "work with not fit (synonym of doesnt fit)" in {
+    not fit <h2>Unic AEM Testing - False Text and Tag</h2>
   }
 }

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/LoggedInSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/LoggedInSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.NotFit
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class LoggedInSpec extends ScalaWebTestBaseSpec{

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/LoginSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/LoginSpec.scala
@@ -1,6 +1,6 @@
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.{NotFit, fits}
+import org.scalawebtest.core.gauge.HtmlGauge.{NotFit, fits}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class LoginSpec extends ScalaWebTestBaseSpec{

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/RegexSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/RegexSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.fits
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class RegexSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SimpleGaugeSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SimpleGaugeSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.fit
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class SimpleGaugeSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SynonymSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SynonymSpec.scala
@@ -14,7 +14,6 @@
  */
 package org.scalawebtest.integration.gauge
 
-import org.scalawebtest.core.gauge.Gauge.{NotFit, doesnt, fit, fits}
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class SynonymSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/js/AjaxSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/js/AjaxSpec.scala
@@ -15,7 +15,6 @@
 package org.scalawebtest.integration.js
 
 import org.scalatest.time.SpanSugar._
-import org.scalawebtest.core.gauge.Gauge.fits
 import org.scalawebtest.integration.ScalaWebTestBaseSpec
 
 class AjaxSpec extends ScalaWebTestBaseSpec {

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/ComponentPropertiesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/ComponentPropertiesSpec.scala
@@ -1,7 +1,7 @@
 package org.scalawebtest.integration.aem
 
 import org.scalawebtest.aem.PageProperties
-import org.scalawebtest.core.gauge.Gauge.fits
+import org.scalawebtest.core.gauge.HtmlGauge.fits
 import org.scalawebtest.integration.extensions.aem.AemModuleScalaWebTestBaseSpec
 
 class ComponentPropertiesSpec extends AemModuleScalaWebTestBaseSpec with PageProperties {

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/FindByResourceTypeSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/FindByResourceTypeSpec.scala
@@ -1,7 +1,7 @@
 package org.scalawebtest.integration.aem
 
 import org.scalawebtest.aem.PageProperties
-import org.scalawebtest.core.gauge.Gauge.fits
+import org.scalawebtest.core.gauge.HtmlGauge.fits
 import org.scalawebtest.integration.extensions.aem.AemModuleScalaWebTestBaseSpec
 import play.api.libs.json.{JsObject, JsValue}
 

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/PagePropertiesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/PagePropertiesSpec.scala
@@ -15,7 +15,7 @@
 package org.scalawebtest.integration.aem
 
 import org.scalawebtest.aem.PageProperties
-import org.scalawebtest.core.gauge.Gauge.fits
+import org.scalawebtest.core.gauge.HtmlGauge.fits
 import org.scalawebtest.integration.extensions.aem.AemModuleScalaWebTestBaseSpec
 import play.api.libs.json.{JsObject, JsValue}
 

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/SuffixPropertiesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/aem/SuffixPropertiesSpec.scala
@@ -1,7 +1,7 @@
 package org.scalawebtest.integration.aem
 
 import org.scalawebtest.aem.PageProperties
-import org.scalawebtest.core.gauge.Gauge.fits
+import org.scalawebtest.core.gauge.HtmlGauge.fits
 import org.scalawebtest.integration.extensions.aem.AemModuleScalaWebTestBaseSpec
 
 class SuffixPropertiesSpec extends AemModuleScalaWebTestBaseSpec with PageProperties {

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/ContainsElementFittingSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/ContainsElementFittingSpec.scala
@@ -1,10 +1,8 @@
 package org.scalawebtest.integration.json
 
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
 import play.api.libs.json.{JsLookupResult, JsValue, Json}
 
-class ContainsElementFittingSpec extends ScalaWebTestBaseSpec {
+class ContainsElementFittingSpec extends ScalaWebTestJsonBaseSpec {
   path = "/jsonResponse.json.jsp"
   def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
   def universities: JsLookupResult = { dijkstra \ "universities" }

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypeMismatchBehavior.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypeMismatchBehavior.scala
@@ -1,13 +1,11 @@
 package org.scalawebtest.integration.json
 
 import org.scalatest.exceptions.TestFailedException
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
 import play.api.libs.json.Json
 
 //Can only be used in specs which request /jsonResponse.json.jsp
 trait FitsTypeMismatchBehavior {
-  self: ScalaWebTestBaseSpec =>
+  self: ScalaWebTestJsonBaseSpec =>
 
   def jsonGaugeFitting(gaugeType: GaugeType): Unit = {
     def dijkstra = Json.parse(webDriver.getPageSource)

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypesAndArraySizesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypesAndArraySizesSpec.scala
@@ -1,11 +1,9 @@
 package org.scalawebtest.integration.json
 
 import org.scalatest.exceptions.TestFailedException
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
 import play.api.libs.json.{JsValue, Json}
 
-class FitsTypesAndArraySizesSpec extends ScalaWebTestBaseSpec with FitsTypeMismatchBehavior {
+class FitsTypesAndArraySizesSpec extends ScalaWebTestJsonBaseSpec with FitsTypeMismatchBehavior {
   path = "/jsonResponse.json.jsp"
   def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
 

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsTypesSpec.scala
@@ -1,10 +1,8 @@
 package org.scalawebtest.integration.json
 
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
 import play.api.libs.json.{JsValue, Json}
 
-class FitsTypesSpec extends ScalaWebTestBaseSpec with FitsTypeMismatchBehavior {
+class FitsTypesSpec extends ScalaWebTestJsonBaseSpec with FitsTypeMismatchBehavior {
   path = "/jsonResponse.json.jsp"
   def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
 

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsValuesSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/FitsValuesSpec.scala
@@ -1,11 +1,9 @@
 package org.scalawebtest.integration.json
 
 import org.scalatest.exceptions.TestFailedException
-import org.scalawebtest.integration.ScalaWebTestBaseSpec
-import org.scalawebtest.json.JsonGaugeBuilder._
 import play.api.libs.json.{JsValue, Json}
 
-class FitsValuesSpec extends ScalaWebTestBaseSpec with FitsTypeMismatchBehavior {
+class FitsValuesSpec extends ScalaWebTestJsonBaseSpec with FitsTypeMismatchBehavior {
   path = "/jsonResponse.json.jsp"
   def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
 

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/JsonGaugeFromResponseObjectSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/JsonGaugeFromResponseObjectSpec.scala
@@ -1,8 +1,9 @@
 package org.scalawebtest.integration.json
 
-import org.scalawebtest.json.JsonGaugeFromResponse.fitsValues
+import org.scalawebtest.integration.ScalaWebTestBaseSpec
+import org.scalawebtest.json.JsonGaugeFromResponse._
 
-class DocumentFitsValuesSpec extends ScalaWebTestJsonBaseSpec {
+class JsonGaugeFromResponseObjectSpec extends ScalaWebTestBaseSpec {
   path = "/jsonResponse.json.jsp"
 
   "FitsValues" should "report success, when the json gauge contains the same values as the response it is tested against" in {

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/JsonGaugeObjectSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/JsonGaugeObjectSpec.scala
@@ -1,0 +1,25 @@
+package org.scalawebtest.integration.json
+
+import org.scalawebtest.integration.ScalaWebTestBaseSpec
+import org.scalawebtest.json.JsonGauge._
+import play.api.libs.json.{JsValue, Json}
+
+class JsonGaugeObjectSpec extends ScalaWebTestBaseSpec {
+  path = "/jsonResponse.json.jsp"
+  def dijkstra: JsValue = Json.parse(webDriver.getPageSource)
+
+  "Fits types" should "report success, when the json gauge contains the same values as the response it is tested against" in {
+    dijkstra fits values of
+      """{
+        | "name": "Dijkstra",
+        | "firstName": "Edsger",
+        | "yearOfBirth": 1930,
+        | "isTuringAwardWinner": true,
+        | "theories": [
+        |   "shortest path",
+        |   "graph theory"
+        | ]
+        |}
+      """.stripMargin
+  }
+}

--- a/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/ScalaWebTestJsonBaseSpec.scala
+++ b/scalawebtest-integration/src/it/scala_2.11+/org/scalawebtest/integration/json/ScalaWebTestJsonBaseSpec.scala
@@ -1,0 +1,9 @@
+package org.scalawebtest.integration.json
+
+import org.scalawebtest.core.IntegrationFlatSpec
+import org.scalawebtest.json.JsonGauge
+
+trait ScalaWebTestJsonBaseSpec extends IntegrationFlatSpec with JsonGauge{
+    override val host = "http://localhost:9090"
+    override val projectRoot = ""
+}

--- a/scalawebtest-json/src/main/scala_2.11+/org/scalawebtest/json/Gauge.scala
+++ b/scalawebtest-json/src/main/scala_2.11+/org/scalawebtest/json/Gauge.scala
@@ -20,16 +20,16 @@ import play.api.libs.json._
 import scala.language.implicitConversions
 
 /**
-  * One should not have to create an instance of [[JsonGauge]] manually. Use one of the provided Builder.
-  * Either [[JsonGaugeBuilder]] or [[JsonGaugeFromResponse]]
+  * One should not have to create an instance of [[Gauge]] manually. Use one of the provided Builder.
+  * Either [[JsonGauge]] or [[JsonGaugeFromResponse]]
   *
   * @param testee JsValue to be tested with the gauge
   * @param fitValues whether the [[testee]] is expected to fit the gauge values
   * @param fitArraySizes whether the [[testee]] is expected to fit the sizes of contained arrays
   */
-case class JsonGauge(testee: JsValue, fitValues: Boolean, fitArraySizes: Boolean) extends Assertions with AppendedClues with Matchers {
+case class Gauge(testee: JsValue, fitValues: Boolean, fitArraySizes: Boolean) extends Assertions with AppendedClues with Matchers {
 
-  def withTestee(testee: JsValue) = JsonGauge(testee, this.fitValues, this.fitArraySizes)
+  def withTestee(testee: JsValue) = Gauge(testee, this.fitValues, this.fitArraySizes)
 
   def fits(definition: JsValue) {
     definition match {

--- a/scalawebtest-json/src/main/scala_2.11+/org/scalawebtest/json/JsonGaugeFromResponse.scala
+++ b/scalawebtest-json/src/main/scala_2.11+/org/scalawebtest/json/JsonGaugeFromResponse.scala
@@ -17,23 +17,35 @@ package org.scalawebtest.json
 import org.openqa.selenium.WebDriver
 import play.api.libs.json.Json
 
+
+object JsonGaugeFromResponse extends JsonGaugeFromResponse
+
 /**
-  *
+  * Allows to test if the complete response fits the provided [[org.scalawebtest.json.Gauge]] definition.
   */
-object JsonGaugeFromResponse {
+trait JsonGaugeFromResponse {
+  /**
+    * Test if all types of the response fit the provided [[org.scalawebtest.json.Gauge]] definition.
+    */
   def fitsTypes(definition: String)(implicit webDriver: WebDriver): Unit = {
     def document = Json.parse(webDriver.getPageSource)
-    JsonGauge(document, fitValues = false, fitArraySizes = false).fits(Json.parse(definition))
+    Gauge(document, fitValues = false, fitArraySizes = false).fits(Json.parse(definition))
   }
 
+  /**
+    * Test if all types and array sizes of the response fit the provided [[org.scalawebtest.json.Gauge]] definition.
+    */
   def fitsTypesAndArraySizes(definition: String)(implicit webDriver: WebDriver): Unit = {
     def document = Json.parse(webDriver.getPageSource)
-    JsonGauge(document, fitValues = false, fitArraySizes = true).fits(Json.parse(definition))
+    Gauge(document, fitValues = false, fitArraySizes = true).fits(Json.parse(definition))
   }
 
+  /**
+    * Test if all values of the response fit the provided [[org.scalawebtest.json.Gauge]] definition.
+    */
   def fitsValues(definition: String)(implicit webDriver: WebDriver): Unit = {
     def document = Json.parse(webDriver.getPageSource)
-    JsonGauge(document, fitValues = true, fitArraySizes = true).fits(Json.parse(definition))
+    Gauge(document, fitValues = true, fitArraySizes = true).fits(Json.parse(definition))
   }
 }
 


### PR DESCRIPTION
…Gauge object to a trait named HtmlGauge and create two objects Gauge and HtmlGauge which extend it, the Gauge object is immediately deprecated and only to provide a clean upgrade path,

changed the JsonGaugeBuilder object to a trait named JsonGauge, created an object named JsonGauge which extends the JsonGauge trait
changed the JsonGaugeFromResponse object to a trait and created an object with identical name, which in turn extends the JsonGaugeFromResponse trait
changed the ElementGaugeBuilder object to a trait named HtmlElementGauge, create an object named HtmlElementGauge which extends the HtmlElementGauge trait
Users can now choose if they want to import single functions from the HtmlGauge, HtmlElementGauge, JsonGauge or JsonGaugeFromResponse object (the same way they had to do it before Release 1.1.0), or if they rather extend the HtmlGauge, HtmlElementGauge, JsonGauge or JsonGaugeFromResponse trait. The latter being the recommended way now