### PR TITLE
ScalaWebTest-36 HTML Gauges can't handle ID-less sibling elements of …

### DIFF
--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SiblingsWithoutIdSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/SiblingsWithoutIdSpec.scala
@@ -1,0 +1,18 @@
+package org.scalawebtest.integration.gauge
+
+import org.scalawebtest.integration.ScalaWebTestBaseSpec
+
+class SiblingsWithoutIdSpec extends ScalaWebTestBaseSpec {
+
+  path = "/siblingsWithoutId.jsp"
+
+  "The HtmlGauge" should "handle ID-less sibling elements of the same type correctly" in {
+    fits(
+      <select name="foobar" class="select">
+        <option value="foo" selected="selected">foo</option>
+        <option value="bar">bar</option>
+        <option value="baz">baz</option>
+      </select>
+    )
+  }
+}

--- a/scalawebtest-integration/src/main/webapp/siblingsWithoutId.jsp
+++ b/scalawebtest-integration/src/main/webapp/siblingsWithoutId.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8"%>
+<html>
+<head></head>
+<body>
+<select name="foobar" class="select" title="select with siblings">
+    <option value="foo" selected="selected">foo</option>
+    <option value="bar">bar</option>
+    <option value="baz">baz</option>
+</select>
+</body>
+</html>


### PR DESCRIPTION
…the same type - added integration test to assert handling of ID-less sibling elements works as expected