### PR TITLE
Switch to https for external resources

### DIFF
--- a/docs/_includes/head.ext
+++ b/docs/_includes/head.ext
@@ -41,8 +41,8 @@
     <meta property="og:description" content="{{page.description}}" />
     <meta property="og:site_name" content="scalawebtest.org" />
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,100,300,700,500,900' rel='stylesheet' type='text/css'>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,300,700,500,900' rel='stylesheet' type='text/css'>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <script src="{{site.url}}/js/gttBtn.js"></script>
     <script src="{{site.url}}/js/navbar.js"></script>
     <script src="{{site.url}}/js/skel.min.js"></script>


### PR DESCRIPTION
to avoid mixed content warnings