### PR TITLE
Feature/scalawebtest 47 rebased

### DIFF
--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
@@ -85,7 +85,7 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
     definition.theSeq.foreach(gaugeElement => {
       val fit = nodeFits(Option(domNode.getParentNode).getOrElse(domNode), gaugeElement, None, MISFIT_RELEVANCE_START_VALUE)
       if (fit.isDefined) {
-        fail(s"Current document matches the provided gauge, although expected not to!\n Gauge spec: $gaugeElement\n Fitting node: ${fit.get.domNode.prettyString()} found")
+        fail(s"Current element matches the provided gauge, although expected not to!\n Gauge spec: $gaugeElement\n Fitting node: ${fit.get.domNode.prettyString()} found")
       }
       //when proceeding to the next definition, old misfits do not matter anymore
       misfitHolder.wipe()

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
@@ -66,49 +66,30 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
     })
   }
 
-  def elementFits(domNode: DomNode): Unit = {
-    if (definition.theSeq.length != 1) {
-      fail("Exactly one top level node expected, in the gauge definition.")
-    }
-
-    definition.theSeq.head match {
-      case elem: Elem =>
-        if (domNode.getLocalName != elem.label) {
-          misfitHolder.addMisfit(Misfit(MISFIT_RELEVANCE_START_VALUE, s"Expected <${elem.label}>, but was <${domNode.getLocalName}> in ${domNode.prettyString()}"))
-          failAndReportMisfit()
-        }
-        if (!verifyClassesOnCandidate(domNode, elem, MISFIT_RELEVANCE_START_VALUE)) {
-          failAndReportMisfit()
-        }
-        val fittingNode = verifyCandidate(domNode, elem, None, MISFIT_RELEVANCE_START_VALUE)
-        if (fittingNode.isEmpty) {
-          failAndReportMisfit()
-        }
-      //only element allowed as top level gauge definition, when using elementFits
-      case invalid => fail("Gauge definition contained invalid top level element " + invalid)
-    }
+  def fits(domNode: DomNode): Unit = {
+    var fittingNodes = List[Fit]()
+    definition.theSeq.foreach(gaugeElement => {
+      val fittingNode = nodeFits(Option(domNode.getParentNode).getOrElse(domNode), gaugeElement, None, MISFIT_RELEVANCE_START_VALUE)
+      if (fittingNode.isEmpty) {
+        failAndReportMisfit()
+      }
+      else {
+        fittingNodes = fittingNode.get :: fittingNodes
+        //when proceeding to the next definition, old misfits do not matter anymore
+        misfitHolder.wipe()
+      }
+    })
   }
 
-  def elementDoesNotFit(domNode: DomNode): Unit = {
-    if (definition.theSeq.length != 1) {
-      fail("Exactly one top level node expected, in the gauge definition.")
-    }
-
-    definition.theSeq.head match {
-      case elem: Elem =>
-        if (domNode.getLocalName != elem.label) {
-          misfitHolder.addMisfit(Misfit(MISFIT_RELEVANCE_START_VALUE, s"Expected <${elem.label}>, but was <${domNode.getLocalName}> in ${domNode.prettyString()}"))
-          failAndReportMisfit()
-        }
-        if (verifyClassesOnCandidate(domNode, elem, MISFIT_RELEVANCE_START_VALUE)) {
-          val fittingNode = verifyCandidate(domNode, elem, None, MISFIT_RELEVANCE_START_VALUE)
-          if (fittingNode.isDefined) {
-            fail(s"Current element matches the provided gauge, although expected not to!\n Gauge spec: $elem\n Fitting node: ${fittingNode.get.domNode.prettyString()} found")
-          }
-        }
-      //only element allowed as top level gauge definition, when using elementFits
-      case invalid => fail("Gauge definition contained invalid top level element " + invalid)
-    }
+  def doesNotFit(domNode: DomNode): Unit = {
+    definition.theSeq.foreach(gaugeElement => {
+      val fit = nodeFits(Option(domNode.getParentNode).getOrElse(domNode), gaugeElement, None, MISFIT_RELEVANCE_START_VALUE)
+      if (fit.isDefined) {
+        fail(s"Current document matches the provided gauge, although expected not to!\n Gauge spec: $gaugeElement\n Fitting node: ${fit.get.domNode.prettyString()} found")
+      }
+      //when proceeding to the next definition, old misfits do not matter anymore
+      misfitHolder.wipe()
+    })
   }
 
   private def verifyClassesOnCandidate(domNode: DomNode, elem: Elem, misfitRelevance: MisfitRelevance): Boolean = {
@@ -154,7 +135,6 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
 
     node.label + classSelector
   }
-
 
   private def nodeFits(node: DomNode, gaugeDefinition: Seq[Node], previousSibling: Option[DomNode], misfitRelevance: MisfitRelevance): Option[Fit] = {
     val definitionIt = gaugeDefinition.iterator

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
@@ -66,7 +66,7 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
     })
   }
 
-  def fits(domNode: DomNode): Unit = {
+  def elementFits(domNode: DomNode): Unit = {
     var fittingNodes = List[Fit]()
     definition.theSeq.foreach(gaugeElement => {
       val fittingNode = nodeFits(Option(domNode.getParentNode).getOrElse(domNode), gaugeElement, None, MISFIT_RELEVANCE_START_VALUE)
@@ -81,7 +81,7 @@ class Gauge(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver) ex
     })
   }
 
-  def doesNotFit(domNode: DomNode): Unit = {
+  def elementDoesNotFit(domNode: DomNode): Unit = {
     definition.theSeq.foreach(gaugeElement => {
       val fit = nodeFits(Option(domNode.getParentNode).getOrElse(domNode), gaugeElement, None, MISFIT_RELEVANCE_START_VALUE)
       if (fit.isDefined) {
@@ -429,7 +429,7 @@ trait HtmlGauge {
   }
 
   /**
-    * Synonym for [[Gauge.fits]]. Use whatever reads better in your current context.
+    * Synonym for [[Gauge.elementFits]]. Use whatever reads better in your current context.
     */
   def fit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = fits(definition)
 
@@ -444,7 +444,7 @@ trait HtmlGauge {
     /**
       * Assert that the current document `doesnt fit` the html snippet provided as definition for the `Gauge`
       *
-      * To get detailed information about available options in `Gauge` definitions, read the ScalaDoc of [[Gauge.fits]]
+      * To get detailed information about available options in `Gauge` definitions, read the ScalaDoc of [[Gauge.elementFits]]
       */
     def fit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {
       new Gauge(definition).doesNotFit()

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
@@ -56,12 +56,12 @@ trait HtmlElementGauge {
       */
     def fits(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {
       val domNode: DomNode = extractDomNode(element: Element)
-      new Gauge(definition).fits(domNode)
+      new Gauge(definition).elementFits(domNode)
     }
 
     def doesNotFit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {
       val domNode: DomNode = extractDomNode(element: Element)
-      new Gauge(definition).doesNotFit(domNode)
+      new Gauge(definition).elementDoesNotFit(domNode)
     }
 
     def fit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/HtmlElementGauge.scala
@@ -56,12 +56,12 @@ trait HtmlElementGauge {
       */
     def fits(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {
       val domNode: DomNode = extractDomNode(element: Element)
-      new Gauge(definition).elementFits(domNode)
+      new Gauge(definition).fits(domNode)
     }
 
     def doesNotFit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {
       val domNode: DomNode = extractDomNode(element: Element)
-      new Gauge(definition).elementDoesNotFit(domNode)
+      new Gauge(definition).doesNotFit(domNode)
     }
 
     def fit(definition: NodeSeq)(implicit webDriver: WebClientExposingDriver): Unit = {

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementGaugeObjectSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/ElementGaugeObjectSpec.scala
@@ -33,11 +33,18 @@ class ElementGaugeObjectSpec extends ScalaWebTestBaseSpec {
     </a>
   </div>
 
+  /**
+    * Since it possible to run partial matches for the DOM of an entire page, the same should be true for
+    * gauges for parts of the page. Otherwise, the user experience feels inconsistent.
+    *
+    */
+  val partialImageGauge = <figure class="obj_aspect_ratio"></figure>
+
   "The element gauge" should "successfully verify if single elements fit the given gauge" in {
     images.size should be > 5 withClue " - gallery didn't contain the expected amount of images"
 
     for (image <- images) {
-      image fits imageGauge
+      image fits partialImageGauge
     }
   }
 }

--- a/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlElementGaugeSpec.scala
+++ b/scalawebtest-integration/src/it/scala/org/scalawebtest/integration/gauge/HtmlElementGaugeSpec.scala
@@ -75,9 +75,4 @@ class HtmlElementGaugeSpec extends ScalaWebTestBaseSpec with HtmlElementGauge {
       images.next() fits <div class="columns_image"></div> <div class="columns_image"></div>
     }
   }
-  it should "fail if the top level element in the gauge is not the same as the one tested" in {
-    assertThrows[TestFailedException] {
-      images.next() fits <a></a>
-    }
-  }
 }


### PR DESCRIPTION
This pull request replaces https://github.com/unic/ScalaWebTest/pull/48

Because the original pull request remained open for too long, tests failed on Travis. I therefore rebased the original feature branch and pushed it as a new feature branch.