### PR TITLE
Update ScalaTest to 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ import scala.xml.transform.RewriteRule
 lazy val supportedScalaVersions = Seq("2.13.0", "2.12.8", "2.11.12")
 
 val projectVersion = "3.0.2-SNAPSHOT"
-val scalaTestVersion = "3.0.8"
+val scalaTestVersion = "3.1.0"
+val scalaTestSeleniumVersion = "3.1.0.0"
 val seleniumVersion = "3.141.59"
 val htmlUnitVersion = "2.35.1"
 val slf4jVersion = "1.7.26"
@@ -48,6 +49,7 @@ lazy val core = Project(id = "scalawebtest-core", base = file("scalawebtest-core
   .settings(
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalaTestVersion,
+      "org.scalatestplus" %% "selenium-2-45" % scalaTestSeleniumVersion,
       "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion,
       "org.seleniumhq.selenium" % "htmlunit-driver" % htmlUnitVersion,
       "org.jsoup" % "jsoup" % "1.11.3",

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/Login.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/Login.scala
@@ -65,9 +65,9 @@ trait FormBasedLogin extends Login {
       go to loginConfig.loginUri.toString
       logger.info(s"Filling login form at ${loginConfig.loginUri}")
       click on username_fieldname
-      emailField(username_fieldname).value = username
+      emailField(username_fieldname).underlying.sendKeys(username)
       click on password_fieldname
-      pwdField(password_fieldname).value = password
+      pwdField(password_fieldname).underlying.sendKeys(password)
 
       submit()
     })

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/Styles.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/Styles.scala
@@ -14,8 +14,16 @@
  */
 package org.scalawebtest.core
 
-import org.scalatest._
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.refspec.RefSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
   * ScalaTest provides a wide variety of styles. To make the creation of your BaseTrait easier,
@@ -23,25 +31,25 @@ import org.scalatest.refspec.RefSpec
   */
 
 abstract class IntegrationFunSuite extends FunSuiteBehavior with IntegrationSpec
-abstract class FunSuiteBehavior extends FunSuite with Matchers with Inspectors
+abstract class FunSuiteBehavior extends AnyFunSuite with Matchers with Inspectors
 
 abstract class IntegrationFlatSpec extends FlatSpecBehavior with IntegrationSpec
-abstract class FlatSpecBehavior extends FlatSpec with Matchers with Inspectors
+abstract class FlatSpecBehavior extends AnyFlatSpec with Matchers with Inspectors
 
 abstract class IntegrationFunSpec extends FunSpecBehavior with IntegrationSpec
-abstract class FunSpecBehavior extends FunSpec with Matchers with Inspectors
+abstract class FunSpecBehavior extends AnyFunSpec with Matchers with Inspectors
 
 abstract class IntegrationWordSpec extends WordSpecBehavior with IntegrationSpec
-abstract class WordSpecBehavior extends WordSpec with Matchers with Inspectors
+abstract class WordSpecBehavior extends AnyWordSpec with Matchers with Inspectors
 
 abstract class IntegrationFreeSpec extends FreeSpecBehavior with IntegrationSpec
-abstract class FreeSpecBehavior extends FreeSpec with Matchers with Inspectors
+abstract class FreeSpecBehavior extends AnyFreeSpec with Matchers with Inspectors
 
 abstract class IntegrationPropSpec extends  PropSpecBehavior with IntegrationSpec
-abstract class PropSpecBehavior extends PropSpec with Matchers with Inspectors
+abstract class PropSpecBehavior extends AnyPropSpec with Matchers with Inspectors
 
 abstract class IntegrationFeatureSpec extends FeatureSpecBehavior with IntegrationSpec
-abstract class FeatureSpecBehavior extends FeatureSpec with Matchers with Inspectors
+abstract class FeatureSpecBehavior extends AnyFeatureSpec with Matchers with Inspectors
 
 abstract class IntegrationRefSpec extends RefSpecBehavior with IntegrationSpec
 abstract class RefSpecBehavior extends RefSpec with Matchers with Inspectors

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/WebClientExposingDriver.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/WebClientExposingDriver.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
   * Extension of the default HtmlUnitDriver that provides access to some of the web client's options and methods which are hidden in the
   * default implementation.
   */
-class WebClientExposingDriver(version: BrowserVersion) extends HtmlUnitDriver(version) {
+class WebClientExposingDriver(version: BrowserVersion) extends HtmlUnitDriver(version, true) {
 
   /**
     * @return the options object of the WebClient

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/WebClientExposingDriver.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/WebClientExposingDriver.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
   * Extension of the default HtmlUnitDriver that provides access to some of the web client's options and methods which are hidden in the
   * default implementation.
   */
-class WebClientExposingDriver(version: BrowserVersion) extends HtmlUnitDriver(version, true) {
+class WebClientExposingDriver(version: BrowserVersion) extends HtmlUnitDriver(version) {
 
   /**
     * @return the options object of the WebClient

--- a/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
+++ b/scalawebtest-core/src/main/scala/org/scalawebtest/core/gauge/Gauge.scala
@@ -18,7 +18,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element => JElement, Node => JNode, TextNode => JTextNode}
 import org.openqa.selenium.WebDriver
 import org.scalatest.Assertions
-import org.scalatest.words.NotWord
+import org.scalatest.matchers.dsl.NotWord
 import org.scalawebtest.core.gauge.JNodePrettifier.PrettyStringProvider
 
 import scala.annotation.tailrec

--- a/scalawebtest-core/src/test/scala/org/scalawebtest/core/gauge/FragmentParserTest.scala
+++ b/scalawebtest-core/src/test/scala/org/scalawebtest/core/gauge/FragmentParserTest.scala
@@ -15,12 +15,14 @@
 package org.scalawebtest.core.gauge
 
 import org.jsoup.nodes.{Node, TextNode}
-import org.scalatest.{AppendedClues, FreeSpec, Matchers => STMatchers}
+import org.scalatest.AppendedClues
 
 import scala.jdk.CollectionConverters._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.{Matchers => STMatchers}
 
 
-class FragmentParserTest extends FreeSpec with STMatchers with AppendedClues {
+class FragmentParserTest extends AnyFreeSpec with STMatchers with AppendedClues {
   def renderElement(name: String): String = {
     def isSelfClosing: Boolean = List("br", "plaintext").contains(name)
 

--- a/scalawebtest-json/src/main/scala/org/scalawebtest/json/Gauge.scala
+++ b/scalawebtest-json/src/main/scala/org/scalawebtest/json/Gauge.scala
@@ -15,7 +15,8 @@
 package org.scalawebtest.json
 
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{AppendedClues, Assertions, Matchers}
+import org.scalatest.{AppendedClues, Assertions}
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
 import scala.language.implicitConversions

--- a/scalawebtest-json/src/main/scala/org/scalawebtest/json/JsonGaugeBuilder.scala
+++ b/scalawebtest-json/src/main/scala/org/scalawebtest/json/JsonGaugeBuilder.scala
@@ -15,7 +15,8 @@
 package org.scalawebtest.json
 
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.{AppendedClues, Assertions, Matchers}
+import org.scalatest.{AppendedClues, Assertions}
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
 import scala.language.implicitConversions


### PR DESCRIPTION
Closes #106 

* Addressed all deprecation
* Added `"org.scalatestplus" %% "selenium-2-45"` artifact, which is separated from scalatest core artifact.
